### PR TITLE
[Torch] Added mnetv1_ssd_voc Model

### DIFF
--- a/models/torch/README.md
+++ b/models/torch/README.md
@@ -1,1 +1,9 @@
-Torch pre-trained models
+# Torch pre-trained models
+
+This repository contains several Ambarella-pretrained pytorch models.
+
+## MobileNetV1-SSD on VOC
+
+- Filename: `mnetv1_ssd_voc_200.tar.gz`.
+- Pretrained on the VOC dataset.
+- mAP: 0.6760


### PR DESCRIPTION
Adding `mnetv1_ssd_voc` model to repo. The pretrained weight is finetuned on the VOC dataset. This weight is required for the `mnetv1_ssd_voc` example in spongetorch.